### PR TITLE
Remove early production environment check in ACI command to streamlin…

### DIFF
--- a/internal/cli/aci.go
+++ b/internal/cli/aci.go
@@ -39,13 +39,6 @@ func newACICmd() *cobra.Command {
 			// Get environment from root command
 			envName, _ := cmd.Flags().GetString("env")
 
-			// Check for production environment early
-			if envName == envProd || envName == envProduction {
-				logging.Infof("Production deployment is coming soon!")
-				logging.Infof("For now, please use --dry-run to generate the ACI JSON and deploy manually.")
-				return nil
-			}
-
 			cfg := config.Current()
 
 			// Auto-detect environment in CI if not provided


### PR DESCRIPTION
…e environment handling

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the early production-environment guard in `internal/cli/aci.go` so ACI deployments (including prod) follow the standard execution flow.
> 
> - **CLI (ACI)**:
>   - Remove early production check in `internal/cli/aci.go` that logged a message and returned, enabling production deployments to proceed through the normal flow (env detection, config, validation, and deploy).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2f118654949af6e2b6f55288515f78d85e9a6fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->